### PR TITLE
Fix Documentation and Keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ https://github.com/user-attachments/assets/cb142535-fba0-4280-8f11-66ad1ca50ca9
 - Support for multiple online judges ([AtCoder](https://atcoder.jp/), [Codeforces](https://codeforces.com/), [CSES](https://cses.fi))
 - Multi-language support (C++, Python)
 - Automatic problem scraping and test case management
-- Integrated build, run, and debug commands
-- Enhanced test viewer with individual test case management
-- LuaSnip integration for contest-specific snippets
+- Integrated running and debugging
+- Enhanced test viewer
+- Templates via LuaSnip
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -70,3 +70,5 @@ follows:
 - fzf/telescope integration (whichever available)
 - finer-tuned problem limits (i.e. per-problem codeforces time, memory)
 - notify discord members
+- handle infinite output/trimming file to 500 lines (customizable)
+- update barrettruth.com to post

--- a/doc/cp.txt
+++ b/doc/cp.txt
@@ -290,8 +290,8 @@ The test panel uses a three-pane layout for easy comparison: >
 
 Keymaps ~
                                                 *cp-test-keys*
-j / <Down>                      Navigate to next test case
-k / <Up>                        Navigate to previous test case
+<c-n>                           Navigate to next test case
+<c-p>                           Navigate to previous test case
 q                               Exit test panel (restore layout)
 
 Execution Details ~


### PR DESCRIPTION
use `<c-{n,p}>` in the docs 
This is indeed the default for problem movement in the test panel.