### PR TITLE
improve config validation

### DIFF
--- a/lua/cp/config.lua
+++ b/lua/cp/config.lua
@@ -362,7 +362,7 @@ function M.setup(user_config)
       function(v)
         return type(v) == 'number' and v > 0 and v <= 1
       end,
-      'number/decimal between 0 and 1',
+      'decimal between 0 and 1',
     },
     next_test_key = {
       cfg.ui.run.next_test_key,


### PR DESCRIPTION
- actually validate `debug` param is not a boolean
- fix diff mode validation logic to use `vim.validate`