### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,78 @@
+name: Bug Report
+description: Report a bug
+title: 'bug: '
+labels: [bug]
+body:
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      options:
+        - label:
+            I have searched [existing
+            issues](https://github.com/barrettruth/cp.nvim/issues)
+          required: true
+        - label: I have updated to the latest version
+          required: true
+
+  - type: textarea
+    attributes:
+      label: 'Neovim version'
+      description: 'Output of `nvim --version`'
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: 'Operating system'
+      placeholder: 'e.g. Arch Linux, macOS 15, Ubuntu 24.04'
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: What happened? What did you expect?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the bug
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: 'Health check'
+      description: 'Output of `:checkhealth cp`'
+      render: text
+
+  - type: textarea
+    attributes:
+      label: Minimal reproduction
+      description: |
+        Save the script below as `repro.lua`, edit if needed, and run:
+        ```
+        nvim -u repro.lua
+        ```
+        Confirm the bug reproduces with this config before submitting.
+      render: lua
+      value: |
+        vim.env.LAZY_STDPATH = '.repro'
+        load(vim.fn.system('curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua'))()
+        require('lazy.nvim').setup({
+          spec = {
+            {
+              'barrett-ruth/cp.nvim',
+              opts = {},
+            },
+          },
+        })
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions
+    url: https://github.com/barrettruth/cp.nvim/discussions
+    about: Ask questions and discuss ideas

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,30 @@
+name: Feature Request
+description: Suggest a feature
+title: 'feat: '
+labels: [enhancement]
+body:
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      options:
+        - label:
+            I have searched [existing
+            issues](https://github.com/barrettruth/cp.nvim/issues)
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Problem
+      description: What problem does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Alternatives considered


### PR DESCRIPTION
## Summary
- Add bug report template with prerequisites, reproduction steps, and minimal config
- Add feature request template with problem/solution sections
- Add config to disable blank issues and link to discussions

## Test plan
- [ ] Verify templates appear when creating new issues on GitHub
- [ ] Test bug report form renders correctly
- [ ] Test feature request form renders correctly
- [ ] Confirm blank issues are disabled