### PR TITLE
docs: add blank lines before code blocks

### DIFF
--- a/doc/cp.nvim.txt
+++ b/doc/cp.nvim.txt
@@ -206,6 +206,7 @@ Debug Builds ~
 CONFIGURATION                                                      *cp-config*
 
 Configuration is done via `vim.g.cp_config`. Set this before using the plugin:
+
 >lua
     vim.g.cp_config = {
       languages = {
@@ -273,6 +274,7 @@ By default, C++ (g++ with ISO C++17) and Python are preconfigured under
 the default; per-platform overrides can tweak 'extension' or 'commands'.
 
 For example, to run CodeForces contests with Python by default:
+
 >lua
     vim.g.cp_config = {
       platforms = {
@@ -282,8 +284,10 @@ For example, to run CodeForces contests with Python by default:
       },
     }
 <
+
 Any language is supported provided the proper configuration. For example, to
 run CSES problems with Rust using the single schema:
+
 >lua
     vim.g.cp_config = {
       languages = {


### PR DESCRIPTION
Adds blank lines before code blocks in the documentation for better readability and consistency with vimdoc style.