### PR TITLE
refactor: rename `vim.g.cp_config` to `vim.g.cp`

### DIFF
--- a/doc/cp.nvim.txt
+++ b/doc/cp.nvim.txt
@@ -205,9 +205,9 @@ Debug Builds ~
 ==============================================================================
 CONFIGURATION                                                      *cp-config*
 
-Configuration is done via `vim.g.cp_config`. Set this before using the plugin:
+Configuration is done via `vim.g.cp`. Set this before using the plugin:
 >lua
-    vim.g.cp_config = {
+    vim.g.cp = {
       languages = {
         cpp = {
           extension = 'cc',
@@ -274,7 +274,7 @@ the default; per-platform overrides can tweak 'extension' or 'commands'.
 
 For example, to run CodeForces contests with Python by default:
 >lua
-    vim.g.cp_config = {
+    vim.g.cp = {
       platforms = {
         codeforces = {
           default_language  = 'python',
@@ -285,7 +285,7 @@ For example, to run CodeForces contests with Python by default:
 Any language is supported provided the proper configuration. For example, to
 run CSES problems with Rust using the single schema:
 >lua
-    vim.g.cp_config = {
+    vim.g.cp = {
       languages = {
         rust = {
           extension = 'rs',

--- a/lua/cp/init.lua
+++ b/lua/cp/init.lua
@@ -17,7 +17,11 @@ local function ensure_initialized()
   if initialized then
     return
   end
-  local user_config = vim.g.cp_config or {}
+  if vim.g.cp_config then
+    vim.deprecate('vim.g.cp_config', 'vim.g.cp', 'v0.7.6', 'cp.nvim', false)
+    vim.g.cp = vim.g.cp or vim.g.cp_config
+  end
+  local user_config = vim.g.cp or {}
   local config = config_module.setup(user_config)
   config_module.set_current_config(config)
   initialized = true
@@ -34,12 +38,12 @@ function M.is_initialized()
   return initialized
 end
 
----@deprecated Use `vim.g.cp_config` instead
+---@deprecated Use `vim.g.cp` instead
 function M.setup(user_config)
-  vim.deprecate('require("cp").setup()', 'vim.g.cp_config', 'v0.1.0', 'cp.nvim', false)
+  vim.deprecate('require("cp").setup()', 'vim.g.cp', 'v0.1.0', 'cp.nvim', false)
 
   if user_config then
-    vim.g.cp_config = vim.tbl_deep_extend('force', vim.g.cp_config or {}, user_config)
+    vim.g.cp = vim.tbl_deep_extend('force', vim.g.cp or {}, user_config)
   end
 end
 


### PR DESCRIPTION
## Problem

The config variable `vim.g.cp_config` is redundant — the plugin
is already namespaced as cp, so the _config suffix adds nothing.

## Solution

Rename to `vim.g.cp` across the plugin and update docs to match.
