### PR TITLE
fix(setup): set language state before setup_code hook on first open

### DIFF
--- a/lua/cp/setup.lua
+++ b/lua/cp/setup.lua
@@ -160,6 +160,8 @@ function M.setup_contest(platform, contest_id, problem_id, language)
     vim.bo[bufnr].buftype = ''
     vim.bo[bufnr].swapfile = false
 
+    state.set_language(lang)
+
     if cfg.hooks and cfg.hooks.setup_code and not vim.b[bufnr].cp_setup_done then
       local ok = pcall(cfg.hooks.setup_code, state)
       if ok then


### PR DESCRIPTION
## Problem

When opening a contest for the first time (metadata not cached), the
`setup_code` hook fired before `state.set_language()` was called. This
caused `state.get_language()` to return `nil` inside the hook, breaking
any hook logic that depends on the current language (e.g. template
insertion). Subsequent navigations worked fine because `setup_problem()`
had already set the language.

## Solution

Call `state.set_language(lang)` before the `setup_code` hook in the
provisional-buffer branch of `setup_contest()`. The `lang` value is
already computed at that point and is identical to what `setup_problem()`
sets later, so the early write is idempotent.

Closes #236