### PR TITLE
feat: add <Plug> mappings for all primary actions

### DIFF
--- a/doc/cp.nvim.txt
+++ b/doc/cp.nvim.txt
@@ -203,6 +203,43 @@ Debug Builds ~
 <
 
 ==============================================================================
+MAPPINGS                                                        *cp-mappings*
+
+cp.nvim provides <Plug> mappings for all primary actions. These dispatch
+through the same code path as |:CP|.
+
+                                                              *<Plug>(cp-run)*
+<Plug>(cp-run)          Run tests in I/O view. Equivalent to :CP run.
+
+                                                            *<Plug>(cp-panel)*
+<Plug>(cp-panel)        Open full-screen test panel. Equivalent to :CP panel.
+
+                                                             *<Plug>(cp-edit)*
+<Plug>(cp-edit)         Open the test case editor. Equivalent to :CP edit.
+
+                                                             *<Plug>(cp-next)*
+<Plug>(cp-next)         Navigate to the next problem. Equivalent to :CP next.
+
+                                                             *<Plug>(cp-prev)*
+<Plug>(cp-prev)         Navigate to the previous problem. Equivalent to :CP prev.
+
+                                                             *<Plug>(cp-pick)*
+<Plug>(cp-pick)         Launch the contest picker. Equivalent to :CP pick.
+
+                                                         *<Plug>(cp-interact)*
+<Plug>(cp-interact)     Open interactive mode. Equivalent to :CP interact.
+
+Example configuration: >lua
+    vim.keymap.set('n', '<leader>cr', '<Plug>(cp-run)')
+    vim.keymap.set('n', '<leader>cp', '<Plug>(cp-panel)')
+    vim.keymap.set('n', '<leader>ce', '<Plug>(cp-edit)')
+    vim.keymap.set('n', '<leader>cn', '<Plug>(cp-next)')
+    vim.keymap.set('n', '<leader>cN', '<Plug>(cp-prev)')
+    vim.keymap.set('n', '<leader>cc', '<Plug>(cp-pick)')
+    vim.keymap.set('n', '<leader>ci', '<Plug>(cp-interact)')
+<
+
+==============================================================================
 CONFIGURATION                                                      *cp-config*
 
 Configuration is done via `vim.g.cp`. Set this before using the plugin:

--- a/plugin/cp.lua
+++ b/plugin/cp.lua
@@ -154,3 +154,17 @@ end, {
     return {}
   end,
 })
+
+local function cp_action(action)
+  return function()
+    require('cp').handle_command({ fargs = { action } })
+  end
+end
+
+vim.keymap.set('n', '<Plug>(cp-run)', cp_action('run'), { desc = 'CP run tests' })
+vim.keymap.set('n', '<Plug>(cp-panel)', cp_action('panel'), { desc = 'CP open panel' })
+vim.keymap.set('n', '<Plug>(cp-edit)', cp_action('edit'), { desc = 'CP edit test cases' })
+vim.keymap.set('n', '<Plug>(cp-next)', cp_action('next'), { desc = 'CP next problem' })
+vim.keymap.set('n', '<Plug>(cp-prev)', cp_action('prev'), { desc = 'CP previous problem' })
+vim.keymap.set('n', '<Plug>(cp-pick)', cp_action('pick'), { desc = 'CP pick contest' })
+vim.keymap.set('n', '<Plug>(cp-interact)', cp_action('interact'), { desc = 'CP interactive mode' })


### PR DESCRIPTION
## Problem

Users who want keybindings must call `vim.cmd('CP run')` or reach into
internal Lua modules. There is no stable, discoverable public API for
key binding.

## Solution

Define 7 `<Plug>` mappings in `plugin/cp.lua` that dispatch through the
same `handle_command()` code path as `:CP`. Document them in a new
MAPPINGS section in the vimdoc with helptags and an example config.