### PR TITLE
fix: surface runtime check failures as clean notifications

### DIFF
--- a/lua/cp/init.lua
+++ b/lua/cp/init.lua
@@ -15,17 +15,25 @@ local initialized = false
 
 local function ensure_initialized()
   if initialized then
-    return
+    return true
   end
   local user_config = vim.g.cp or {}
-  local config = config_module.setup(user_config)
-  config_module.set_current_config(config)
+  local ok, result = pcall(config_module.setup, user_config)
+  if not ok then
+    local msg = tostring(result):gsub('^.+:%d+: ', '')
+    vim.notify(msg, vim.log.levels.ERROR)
+    return false
+  end
+  config_module.set_current_config(result)
   initialized = true
+  return true
 end
 
 ---@return nil
 function M.handle_command(opts)
-  ensure_initialized()
+  if not ensure_initialized() then
+    return
+  end
   local commands = require('cp.commands')
   commands.handle_command(opts)
 end

--- a/lua/cp/utils.lua
+++ b/lua/cp/utils.lua
@@ -60,7 +60,11 @@ local function find_gnu_time()
 
   _time_cached = true
   _time_path = nil
-  _time_reason = 'GNU time not found'
+  if uname and uname.sysname == 'Darwin' then
+    _time_reason = 'GNU time not found (install via: brew install coreutils)'
+  else
+    _time_reason = 'GNU time not found'
+  end
   return _time_path, _time_reason
 end
 
@@ -251,12 +255,12 @@ function M.check_required_runtime()
 
   local time = M.time_capability()
   if not time.ok then
-    return false, 'GNU time not found: ' .. (time.reason or '')
+    return false, time.reason
   end
 
   local timeout = M.timeout_capability()
   if not timeout.ok then
-    return false, 'GNU timeout not found: ' .. (timeout.reason or '')
+    return false, timeout.reason
   end
 
   if not M.setup_python_env() then
@@ -310,7 +314,11 @@ local function find_gnu_timeout()
 
   _timeout_cached = true
   _timeout_path = nil
-  _timeout_reason = 'GNU timeout not found'
+  if uname and uname.sysname == 'Darwin' then
+    _timeout_reason = 'GNU timeout not found (install via: brew install coreutils)'
+  else
+    _timeout_reason = 'GNU timeout not found'
+  end
   return _timeout_path, _timeout_reason
 end
 


### PR DESCRIPTION
## Problem

When required dependencies (GNU time/timeout, Python env) are missing,
`config.setup()` throws a raw `error()` that surfaces as a Lua traceback.
On macOS without coreutils the message is also redundant ("GNU time not
found: GNU time not found") and offers no install guidance.

## Solution

Wrap `config.setup()` in `pcall` inside `ensure_initialized()`, strip the
Lua source-location prefix, and emit a `vim.notify` at ERROR level. Add
Darwin-specific install guidance to the GNU time/timeout not-found messages.
Pass capability reasons directly instead of wrapping them in a redundant
outer message.