### PR TITLE
fix: only show user-configured platforms in picker

### DIFF
--- a/lua/cp/config.lua
+++ b/lua/cp/config.lua
@@ -292,7 +292,15 @@ end
 ---@return cp.Config
 function M.setup(user_config)
   vim.validate({ user_config = { user_config, { 'table', 'nil' }, true } })
-  local cfg = vim.tbl_deep_extend('force', vim.deepcopy(M.defaults), user_config or {})
+  local defaults = vim.deepcopy(M.defaults)
+  if user_config and user_config.platforms then
+    for plat in pairs(defaults.platforms) do
+      if not user_config.platforms[plat] then
+        defaults.platforms[plat] = nil
+      end
+    end
+  end
+  local cfg = vim.tbl_deep_extend('force', defaults, user_config or {})
 
   if not next(cfg.languages) then
     error('[cp.nvim] At least one language must be configured')


### PR DESCRIPTION
## Problem

`tbl_deep_extend` merges the user's `platforms` table on top of defaults,
so all four default platforms survive even when the user only configures a
subset. The `:CP pick` picker then shows platforms the user never set up.

## Solution

Before the deep merge in `config.setup()`, prune any default platform not
present in the user's `platforms` table. Per-platform defaults are still
filled in (the user doesn't have to re-specify every field), but only
explicitly configured platforms appear in the picker and elsewhere.