### PR TITLE
fix: always run uv sync to recover from partial installs

### DIFF
--- a/lua/cp/utils.lua
+++ b/lua/cp/utils.lua
@@ -175,22 +175,17 @@ function M.setup_python_env()
 
   if vim.fn.executable('uv') == 1 then
     local plugin_path = M.get_plugin_path()
-    local venv_dir = plugin_path .. '/.venv'
 
-    if vim.fn.isdirectory(venv_dir) == 0 then
-      logger.log('Setting up Python environment for scrapers...')
-      local env = vim.fn.environ()
-      env.VIRTUAL_ENV = ''
-      env.PYTHONPATH = ''
-      env.CONDA_PREFIX = ''
-      local result = vim
-        .system({ 'uv', 'sync' }, { cwd = plugin_path, text = true, env = env })
-        :wait()
-      if result.code ~= 0 then
-        logger.log('Failed to setup Python environment: ' .. result.stderr, vim.log.levels.ERROR)
-        return false
-      end
-      logger.log('Python environment setup complete.')
+    local env = vim.fn.environ()
+    env.VIRTUAL_ENV = ''
+    env.PYTHONPATH = ''
+    env.CONDA_PREFIX = ''
+    local result = vim
+      .system({ 'uv', 'sync' }, { cwd = plugin_path, text = true, env = env })
+      :wait()
+    if result.code ~= 0 then
+      logger.log('Failed to setup Python environment: ' .. result.stderr, vim.log.levels.ERROR)
+      return false
     end
 
     python_env_setup = true


### PR DESCRIPTION
## Problem

`setup_python_env()` skips `uv sync` when `.venv/` already exists. If a
previous sync was interrupted (e.g. network timeout on slow wifi), the
directory exists but is broken, and every subsequent session silently uses
a corrupt environment. The user has to manually delete `.venv` and re-run
the install command.

## Solution

Remove the `isdirectory` guard and always run `uv sync`. It is idempotent
and near-instant when dependencies are already installed, so the only cost
is one subprocess call per Neovim session.