### PR TITLE
feat: add debug logging to python env, scraper, and runner

### DIFF
--- a/lua/cp/runner/execute.lua
+++ b/lua/cp/runner/execute.lua
@@ -43,6 +43,7 @@ end
 function M.compile(compile_cmd, substitutions, on_complete)
   local cmd = substitute_template(compile_cmd, substitutions)
   local sh = table.concat(cmd, ' ') .. ' 2>&1'
+  logger.log('compile: ' .. sh)
 
   local t0 = vim.uv.hrtime()
   vim.system({ 'sh', '-c', sh }, { text = false }, function(r)
@@ -119,6 +120,7 @@ function M.run(cmd, stdin, timeout_ms, memory_mb, on_complete)
   local sec = math.ceil(timeout_ms / 1000)
   local timeout_prefix = ('%s -k 1s %ds '):format(timeout_bin, sec)
   local sh = prefix .. timeout_prefix .. ('%s -v sh -c %q 2>&1'):format(time_bin, prog)
+  logger.log('run: ' .. sh)
 
   local t0 = vim.uv.hrtime()
   vim.system({ 'sh', '-c', sh }, { stdin = stdin, text = true }, function(r)

--- a/lua/cp/scraper.lua
+++ b/lua/cp/scraper.lua
@@ -30,6 +30,8 @@ local function run_scraper(platform, subcommand, args, opts)
   vim.list_extend(cmd, { subcommand })
   vim.list_extend(cmd, args)
 
+  logger.log('scraper cmd: ' .. table.concat(cmd, ' '))
+
   local env = vim.fn.environ()
   env.VIRTUAL_ENV = ''
   env.PYTHONPATH = ''

--- a/lua/cp/utils.lua
+++ b/lua/cp/utils.lua
@@ -169,12 +169,14 @@ function M.setup_python_env()
   end
 
   if _nix_python then
+    logger.log('Python env: nix (python=' .. _nix_python .. ')')
     python_env_setup = true
     return true
   end
 
   if vim.fn.executable('uv') == 1 then
     local plugin_path = M.get_plugin_path()
+    logger.log('Python env: uv sync (dir=' .. plugin_path .. ')')
 
     local env = vim.fn.environ()
     env.VIRTUAL_ENV = ''
@@ -187,12 +189,16 @@ function M.setup_python_env()
       logger.log('Failed to setup Python environment: ' .. result.stderr, vim.log.levels.ERROR)
       return false
     end
+    if result.stderr and result.stderr ~= '' then
+      logger.log('uv sync stderr: ' .. result.stderr:gsub('%s+$', ''))
+    end
 
     python_env_setup = true
     return true
   end
 
   if vim.fn.executable('nix') == 1 then
+    logger.log('Python env: nix discovery')
     if discover_nix_python() then
       python_env_setup = true
       return true


### PR DESCRIPTION
## Problem

With `debug = true`, there is not enough diagnostic output to troubleshoot
environment or execution issues. The resolved python path, scraper commands,
uv sync output, and compile/run shell strings are not logged.

## Solution

Add `logger.log` calls at key decision points:

- **Python env resolution**: which path was taken (nix hardcoded, uv sync,
  nix discovery) and the resolved python/plugin path
- **uv sync**: surface stderr when non-empty (dependency resolution details)
- **Scraper**: the full subprocess command being spawned
- **Compile/run**: the shell strings passed to `sh -c`

All gated behind the existing `debug` flag so they only appear when
`debug = true` in `vim.g.cp`.