### PR TITLE
fix: decouple python env setup from config init

### DIFF
--- a/lua/cp/scraper.lua
+++ b/lua/cp/scraper.lua
@@ -25,6 +25,15 @@ end
 ---@param args string[]
 ---@param opts { sync?: boolean, ndjson?: boolean, on_event?: fun(ev: table), on_exit?: fun(result: table) }
 local function run_scraper(platform, subcommand, args, opts)
+  if not utils.setup_python_env() then
+    local msg = 'no Python environment available (install uv or nix)'
+    logger.log(msg, vim.log.levels.ERROR)
+    if opts and opts.on_exit then
+      opts.on_exit({ success = false, error = msg })
+    end
+    return { success = false, error = msg }
+  end
+
   local plugin_path = utils.get_plugin_path()
   local cmd = utils.get_python_cmd(platform, plugin_path)
   vim.list_extend(cmd, { subcommand })

--- a/lua/cp/utils.lua
+++ b/lua/cp/utils.lua
@@ -129,7 +129,8 @@ local function discover_nix_python()
   end
 
   local plugin_path = M.get_plugin_path()
-  logger.log('Building Python environment with nix...', nil, true)
+  vim.notify('[cp.nvim] Building Python environment with nix...', vim.log.levels.INFO)
+  vim.cmd.redraw()
   local result = vim
     .system(
       { 'nix', 'build', plugin_path .. '#pythonEnv', '--no-link', '--print-out-paths' },
@@ -177,6 +178,8 @@ function M.setup_python_env()
   if vim.fn.executable('uv') == 1 then
     local plugin_path = M.get_plugin_path()
     logger.log('Python env: uv sync (dir=' .. plugin_path .. ')')
+    vim.notify('[cp.nvim] Setting up Python environment...', vim.log.levels.INFO)
+    vim.cmd.redraw()
 
     local env = vim.fn.environ()
     env.VIRTUAL_ENV = ''
@@ -262,10 +265,6 @@ function M.check_required_runtime()
   local timeout = M.timeout_capability()
   if not timeout.ok then
     return false, timeout.reason
-  end
-
-  if not M.setup_python_env() then
-    return false, 'no Python environment available (install uv or nix)'
   end
 
   return true


### PR DESCRIPTION
## Problem

`setup_python_env()` is called from `check_required_runtime()` during
`config.setup()`, which runs on the very first `:CP` command. Both `uv sync`
and `nix build` use `vim.system():wait()`, which blocks the Neovim event
loop. During the block:

- The UI is completely frozen — Neovim appears hung
- `vim.schedule` callbacks can't fire, so `logger.log` messages (which wrap
  `vim.notify` in `vim.schedule`) are queued but never rendered
- The user stares at an unresponsive editor with no feedback

## Solution

Two changes that work together:

1. **Remove `setup_python_env()` from `check_required_runtime()`** so that
   config init is instant. The setup is instead called lazily from
   `run_scraper()`, only when a scraper subprocess is actually needed. This
   means `:CP pick` opens the picker immediately rather than blocking.

2. **Use `vim.notify` + `vim.cmd.redraw()` before blocking calls** so that
   the "Setting up Python environment..." notification renders immediately
   via a forced screen repaint, rather than being queued behind
   `vim.schedule` where it can't fire during `:wait()`.