### PR TITLE
docs: fix dependencies section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ Install using your package manager of choice or via
 luarocks install cp.nvim
 ```
 
-## Optional Dependencies
+## Dependencies
 
-- [uv](https://docs.astral.sh/uv/) for problem scraping
 - GNU [time](https://www.gnu.org/software/time/) and
   [timeout](https://www.gnu.org/software/coreutils/manual/html_node/timeout-invocation.html)
+- [uv](https://docs.astral.sh/uv/) or [nix](https://nixos.org/) for problem
+  scraping
 
 ## Quick Start
 


### PR DESCRIPTION
## Problem

The README listed GNU time and timeout as optional dependencies, but
they're required—the plugin errors out during initialization if either
is missing. It also didn't mention nix as an alternative to uv for the
Python scraping environment.

## Solution

Rename the section to "Dependencies", list time/timeout first to
reflect their required status, and add nix alongside uv for scraping.