### PR TITLE
fix(cache): invalidate stale cache on version mismatch

### DIFF
--- a/lua/cp/cache.lua
+++ b/lua/cp/cache.lua
@@ -40,7 +40,6 @@ local M = {}
 
 local CACHE_VERSION = 1
 
-local logger = require('cp.log')
 local cache_file = vim.fn.stdpath('data') .. '/cp-nvim.json'
 local cache_data = {}
 local loaded = false


### PR DESCRIPTION
## Problem

After an install or update, the on-disk cache (`cp-nvim.json`) may contain
data written by an older version of the plugin whose format no longer matches
what the current code expects.

## Solution

Embed a `CACHE_VERSION` in every saved cache file. On load, if the stored
version is missing or differs from the current one, wipe the cache and
rewrite it. Corrupt (non-decodable) cache files are handled the same way
instead of only logging an error.

Future schema changes just need to bump `CACHE_VERSION`.