### PR TITLE
fix: replace deprecated vim.loop with vim.uv

### DIFF
--- a/lua/cp/health.lua
+++ b/lua/cp/health.lua
@@ -13,7 +13,7 @@ local function check()
     vim.health.error('cp.nvim requires Neovim 0.10.0+')
   end
 
-  local uname = vim.loop.os_uname()
+  local uname = vim.uv.os_uname()
   if uname.sysname == 'Windows_NT' then
     vim.health.error('Windows is not supported')
   end

--- a/lua/cp/scraper.lua
+++ b/lua/cp/scraper.lua
@@ -57,7 +57,7 @@ local function run_scraper(platform, subcommand, args, opts)
   env.CONDA_PREFIX = ''
 
   if opts and opts.ndjson then
-    local uv = vim.loop
+    local uv = vim.uv
     local stdout = uv.new_pipe(false)
     local stderr = uv.new_pipe(false)
     local buf = ''

--- a/lua/cp/setup.lua
+++ b/lua/cp/setup.lua
@@ -179,7 +179,7 @@ function M.setup_contest(platform, contest_id, problem_id, language)
       contest_id = contest_id,
       language = lang,
       requested_problem_id = problem_id,
-      token = vim.loop.hrtime(),
+      token = vim.uv.hrtime(),
     })
 
     logger.log('Fetching contests problems...', vim.log.levels.INFO, true)

--- a/lua/cp/utils.lua
+++ b/lua/cp/utils.lua
@@ -5,7 +5,7 @@ local logger = require('cp.log')
 local _nix_python = nil
 local _nix_discovered = false
 
-local uname = vim.loop.os_uname()
+local uname = vim.uv.os_uname()
 
 local _time_cached = false
 local _time_path = nil
@@ -336,7 +336,7 @@ function M.timeout_capability()
 end
 
 function M.cwd_executables()
-  local uv = vim.uv or vim.loop
+  local uv = vim.uv
   local req = uv.fs_scandir('.')
   if not req then
     return {}


### PR DESCRIPTION
## Problem

`vim.loop` is deprecated since Neovim 0.10 in favour of `vim.uv`. Five call sites across the codebase still used the old alias, causing deprecation warnings.

## Solution

Replace every `vim.loop` reference with `vim.uv` directly. The existing compat guard in `utils.lua` (`vim.uv or vim.loop`) is simplified to `vim.uv` for consistency.