### PR TITLE
refactor(submit): consolidate credentials into main cache file

### DIFF
--- a/lua/cp/cache.lua
+++ b/lua/cp/cache.lua
@@ -371,8 +371,29 @@ function M.get_contest_start_time(platform, contest_id)
   return cache_data[platform][contest_id].start_time
 end
 
+---@param platform string
+---@return table?
+function M.get_credentials(platform)
+  if not cache_data._credentials then
+    return nil
+  end
+  return cache_data._credentials[platform]
+end
+
+---@param platform string
+---@param creds table
+function M.set_credentials(platform, creds)
+  cache_data._credentials = cache_data._credentials or {}
+  cache_data._credentials[platform] = creds
+  M.save()
+end
+
 function M.clear_all()
+  local creds = cache_data._credentials
   cache_data = {}
+  if creds then
+    cache_data._credentials = creds
+  end
   M.save()
 end
 

--- a/lua/cp/submit.lua
+++ b/lua/cp/submit.lua
@@ -1,43 +1,11 @@
 local M = {}
 
+local cache = require('cp.cache')
 local logger = require('cp.log')
 local state = require('cp.state')
 
-local credentials_file = vim.fn.stdpath('data') .. '/cp-nvim-credentials.json'
-
-local function load_credentials(platform)
-  if vim.fn.filereadable(credentials_file) ~= 1 then
-    return nil
-  end
-  local content = vim.fn.readfile(credentials_file)
-  if #content == 0 then
-    return nil
-  end
-  local ok, data = pcall(vim.json.decode, table.concat(content, '\n'))
-  if not ok then
-    return nil
-  end
-  return data[platform]
-end
-
-local function save_credentials(platform, creds)
-  local data = {}
-  if vim.fn.filereadable(credentials_file) == 1 then
-    local content = vim.fn.readfile(credentials_file)
-    if #content > 0 then
-      local ok, decoded = pcall(vim.json.decode, table.concat(content, '\n'))
-      if ok then
-        data = decoded
-      end
-    end
-  end
-  data[platform] = creds
-  vim.fn.mkdir(vim.fn.fnamemodify(credentials_file, ':h'), 'p')
-  vim.fn.writefile({ vim.json.encode(data) }, credentials_file)
-end
-
 local function prompt_credentials(platform, callback)
-  local saved = load_credentials(platform)
+  local saved = cache.get_credentials(platform)
   if saved and saved.username and saved.password then
     callback(saved)
     return
@@ -55,7 +23,7 @@ local function prompt_credentials(platform, callback)
       return
     end
     local creds = { username = username, password = password }
-    save_credentials(platform, creds)
+    cache.set_credentials(platform, creds)
     callback(creds)
   end)
 end


### PR DESCRIPTION
## Problem

Credentials were stored in a separate file (`cp-nvim-credentials.json`) alongside the main `cp-nvim.json` cache. Two files for one plugin's persistent state was unnecessary overhead.

## Solution

Add `get_credentials`/`set_credentials` to `cache.lua`, storing credentials under `_credentials[platform]` in the shared cache. Update `clear_all()` to preserve `_credentials` across cache wipes so `:CP cache clear` never loses login data. Remove the separate file, `load_credentials`, and `save_credentials` from `submit.lua`.