### PR TITLE
fix(edit): clean up buffers on close and support :w to save

### DIFF
--- a/lua/cp/ui/edit.lua
+++ b/lua/cp/ui/edit.lua
@@ -328,7 +328,6 @@ setup_keybindings = function(buf)
   })
 end
 
-
 function M.toggle_edit(test_index)
   if edit_state then
     save_all_tests()


### PR DESCRIPTION
## Problem

Two issues with the test editor. Closing it left `cp://test-N-*`
buffers alive, so reopening with `:CP edit` hit `E95: Buffer with
this name already exists`. Separately, `buftype=nofile` rejected
`:w`, which was counterintuitive in an editable grid.

## Solution

Delete all test buffers during `toggle_edit` teardown before
clearing `edit_state`. Switch `buftype` to `acwrite` and add a
`BufWriteCmd` autocmd that calls `save_all_tests()` and clears the
modified flag. Hoisted `save_all_tests` above `setup_keybindings`
so the autocmd closure can reference it. Also applied `acwrite` to
dynamically added test buffers in `add_new_test`.