### PR TITLE
refactor(credentials): rename set/clear to login/logout/clear

### DIFF
--- a/doc/cp.nvim.txt
+++ b/doc/cp.nvim.txt
@@ -433,27 +433,29 @@ COMMANDS                                                         *cp-commands*
                                 Cancel an active race countdown.
 
         Credential Commands ~
-            :CP credentials set [platform]
+            :CP credentials login [platform]
                                 Set or update stored credentials for a platform.
                                 Always prompts for username and password,
                                 overwriting any previously saved credentials.
                                 If [platform] is omitted, uses the active platform.
                                 Examples: >
-                                    :CP credentials set atcoder
-                                    :CP credentials set codeforces
+                                    :CP credentials login atcoder
+                                    :CP credentials login codeforces
 <
-            :CP credentials clear [platform]
-                                Remove stored credentials. Without [platform],
-                                clears credentials for all platforms.
+            :CP credentials logout [platform]
+                                Remove stored credentials for a platform.
+                                If [platform] is omitted, uses the active platform.
                                 Examples: >
-                                    :CP credentials clear atcoder
-                                    :CP credentials clear
+                                    :CP credentials logout atcoder
+<
+            :CP credentials clear
+                                Remove stored credentials for all platforms.
 <
         Submit Commands ~
             :CP submit [--lang {language}]
                                 Submit the current solution to the online
                                 judge. Uses stored credentials (set via
-                                :CP credentials set). Prompts on first use
+                                :CP credentials login). Prompts on first use
                                 if no credentials are saved.
                                 --lang: Submit solution for a specific language.
 
@@ -714,7 +716,7 @@ Example: Setting up and solving AtCoder contest ABC324
 
 8. Submit solution: >
     :CP submit
-<   Prompts for credentials on first use and submits to AtCoder.
+<   Uses stored credentials and submits to AtCoder.
 
 ==============================================================================
 I/O VIEW                                                          *cp-io-view*
@@ -968,13 +970,17 @@ Manage stored login credentials for platform submission.
 Credentials are stored under _credentials in the main cache file
 (stdpath('data')/cp-nvim.json). Use :CP cache read to inspect them.
 
-:CP credentials set [platform]
+:CP credentials login [platform]
         Set or update credentials for a platform. Always prompts for
         username and password, overwriting any previously saved values.
         Omit [platform] to use the currently active platform.
 
-:CP credentials clear [platform]
-        Remove stored credentials. Without [platform], clears all platforms.
+:CP credentials logout [platform]
+        Remove stored credentials for a platform.
+        Omit [platform] to use the currently active platform.
+
+:CP credentials clear
+        Remove stored credentials for all platforms.
 
 ==============================================================================
 SUBMIT                                                               *cp-submit*
@@ -983,7 +989,7 @@ Submit the current solution to the online judge.
 
 :CP submit [--lang {language}]
         Submit the current solution. Uses stored credentials (set via
-        :CP credentials set). Prompts on first use if no credentials
+        :CP credentials login). Prompts on first use if no credentials
         are saved.
         --lang: Override the language to submit.
 

--- a/lua/cp/commands/init.lua
+++ b/lua/cp/commands/init.lua
@@ -86,13 +86,21 @@ local function parse_command(args)
     elseif first == 'credentials' then
       local subcommand = args[2]
       if not subcommand then
-        return { type = 'error', message = 'credentials command requires subcommand (set, clear)' }
+        return {
+          type = 'error',
+          message = 'credentials command requires subcommand (login, logout, clear)',
+        }
       end
-      if vim.tbl_contains({ 'set', 'clear' }, subcommand) then
+      if vim.tbl_contains({ 'login', 'logout' }, subcommand) then
         return {
           type = 'credentials',
           subcommand = subcommand,
           platform = args[3],
+        }
+      elseif subcommand == 'clear' then
+        return {
+          type = 'credentials',
+          subcommand = 'clear',
         }
       else
         return { type = 'error', message = 'unknown credentials subcommand: ' .. subcommand }
@@ -368,10 +376,12 @@ function M.handle_command(opts)
     setup.setup_contest(platform, contest_id, problem_id, cmd.language)
   elseif cmd.type == 'credentials' then
     local creds = require('cp.credentials')
-    if cmd.subcommand == 'set' then
-      creds.set(cmd.platform)
+    if cmd.subcommand == 'login' then
+      creds.login(cmd.platform)
+    elseif cmd.subcommand == 'logout' then
+      creds.logout(cmd.platform)
     elseif cmd.subcommand == 'clear' then
-      creds.clear(cmd.platform)
+      creds.clear()
     end
   elseif cmd.type == 'cache' then
     local cache_commands = require('cp.commands.cache')

--- a/lua/cp/credentials.lua
+++ b/lua/cp/credentials.lua
@@ -4,10 +4,13 @@ local cache = require('cp.cache')
 local logger = require('cp.log')
 local state = require('cp.state')
 
-function M.set(platform)
+function M.login(platform)
   platform = platform or state.get_platform()
   if not platform then
-    logger.log('No platform specified. Usage: :CP credentials set <platform>', vim.log.levels.ERROR)
+    logger.log(
+      'No platform specified. Usage: :CP credentials login <platform>',
+      vim.log.levels.ERROR
+    )
     return
   end
 
@@ -29,14 +32,24 @@ function M.set(platform)
   end)
 end
 
-function M.clear(platform)
+function M.logout(platform)
+  platform = platform or state.get_platform()
+  if not platform then
+    logger.log(
+      'No platform specified. Usage: :CP credentials logout <platform>',
+      vim.log.levels.ERROR
+    )
+    return
+  end
   cache.load()
   cache.clear_credentials(platform)
-  if platform then
-    logger.log(platform .. ' credentials cleared', vim.log.levels.INFO, true)
-  else
-    logger.log('all credentials cleared', vim.log.levels.INFO, true)
-  end
+  logger.log(platform .. ' credentials cleared', vim.log.levels.INFO, true)
+end
+
+function M.clear()
+  cache.load()
+  cache.clear_credentials(nil)
+  logger.log('all credentials cleared', vim.log.levels.INFO, true)
 end
 
 return M

--- a/plugin/cp.lua
+++ b/plugin/cp.lua
@@ -104,7 +104,7 @@ end, {
         end
         return filter_candidates(candidates)
       elseif args[2] == 'credentials' then
-        return filter_candidates({ 'set', 'clear' })
+        return filter_candidates({ 'login', 'logout', 'clear' })
       elseif args[2] == 'race' then
         local candidates = { 'stop' }
         vim.list_extend(candidates, platforms)
@@ -126,7 +126,7 @@ end, {
         cache.load()
         local contests = cache.get_cached_contest_ids(args[3])
         return filter_candidates(contests)
-      elseif args[2] == 'credentials' and vim.tbl_contains({ 'set', 'clear' }, args[3]) then
+      elseif args[2] == 'credentials' and vim.tbl_contains({ 'login', 'logout' }, args[3]) then
         return filter_candidates(platforms)
       elseif args[2] == 'cache' and args[3] == 'clear' then
         local candidates = vim.list_extend({}, platforms)


### PR DESCRIPTION
## Problem

The `set` and `clear` subcommands don't clearly convey their intent — `set`
reads like a generic setter rather than an auth action, and `clear` overloads
single-platform and all-platform semantics in one subcommand.

## Solution

Rename `set` to `login`, split `clear` into `logout` (per-platform, defaults
to active) and `clear` (all platforms).

New API:
- `:CP credentials login [platform]` — prompt and save credentials
- `:CP credentials logout [platform]` — remove credentials for one platform
- `:CP credentials clear` — remove all stored credentials