### PR TITLE
refactor(credentials): promote login/logout to top-level actions

### DIFF
--- a/doc/cp.nvim.txt
+++ b/doc/cp.nvim.txt
@@ -433,30 +433,27 @@ COMMANDS                                                         *cp-commands*
                                 Cancel an active race countdown.
 
         Credential Commands ~
-            :CP credentials login [platform]
+            :CP login [platform]
                                 Set or update stored credentials for a platform.
-                                Always prompts for username and password,
-                                overwriting any previously saved credentials.
+                                Prompts for username and password, overwriting
+                                any previously saved credentials.
                                 If [platform] is omitted, uses the active platform.
                                 Examples: >
-                                    :CP credentials login atcoder
-                                    :CP credentials login codeforces
+                                    :CP login atcoder
+                                    :CP login codeforces
 <
-            :CP credentials logout [platform]
+            :CP logout [platform]
                                 Remove stored credentials for a platform.
                                 If [platform] is omitted, uses the active platform.
                                 Examples: >
-                                    :CP credentials logout atcoder
-<
-            :CP credentials clear
-                                Remove stored credentials for all platforms.
+                                    :CP logout atcoder
 <
         Submit Commands ~
             :CP submit [--lang {language}]
                                 Submit the current solution to the online
                                 judge. Uses stored credentials (set via
-                                :CP credentials login). Prompts on first use
-                                if no credentials are saved.
+                                :CP login). Prompts on first use if no
+                                credentials are saved.
                                 --lang: Submit solution for a specific language.
 
         State Restoration ~
@@ -963,34 +960,30 @@ Count down to a contest's start time and automatically run setup at T=0.
 Statusline integration: see |cp-race-status|.
 
 ==============================================================================
-CREDENTIALS                                                       *cp-credentials*
+CREDENTIALS                                                   *cp-credentials*
 
 Manage stored login credentials for platform submission.
 
 Credentials are stored under _credentials in the main cache file
 (stdpath('data')/cp-nvim.json). Use :CP cache read to inspect them.
 
-:CP credentials login [platform]
-        Set or update credentials for a platform. Always prompts for
-        username and password, overwriting any previously saved values.
+:CP login [platform]
+        Set or update credentials for a platform. Prompts for username
+        and password, overwriting any previously saved values.
         Omit [platform] to use the currently active platform.
 
-:CP credentials logout [platform]
+:CP logout [platform]
         Remove stored credentials for a platform.
         Omit [platform] to use the currently active platform.
 
-:CP credentials clear
-        Remove stored credentials for all platforms.
-
 ==============================================================================
-SUBMIT                                                               *cp-submit*
+SUBMIT                                                            *cp-submit*
 
 Submit the current solution to the online judge.
 
 :CP submit [--lang {language}]
         Submit the current solution. Uses stored credentials (set via
-        :CP credentials login). Prompts on first use if no credentials
-        are saved.
+        :CP login). Prompts on first use if no credentials are saved.
         --lang: Override the language to submit.
 
         Platform support:

--- a/lua/cp/commands/init.lua
+++ b/lua/cp/commands/init.lua
@@ -83,28 +83,8 @@ local function parse_command(args)
       else
         return { type = 'action', action = 'interact' }
       end
-    elseif first == 'credentials' then
-      local subcommand = args[2]
-      if not subcommand then
-        return {
-          type = 'error',
-          message = 'credentials command requires subcommand (login, logout, clear)',
-        }
-      end
-      if vim.tbl_contains({ 'login', 'logout' }, subcommand) then
-        return {
-          type = 'credentials',
-          subcommand = subcommand,
-          platform = args[3],
-        }
-      elseif subcommand == 'clear' then
-        return {
-          type = 'credentials',
-          subcommand = 'clear',
-        }
-      else
-        return { type = 'error', message = 'unknown credentials subcommand: ' .. subcommand }
-      end
+    elseif first == 'login' or first == 'logout' then
+      return { type = 'action', action = first, platform = args[2] }
     elseif first == 'stress' then
       return {
         type = 'action',
@@ -345,6 +325,10 @@ function M.handle_command(opts)
       require('cp.race').start(cmd.platform, cmd.contest, cmd.language)
     elseif cmd.action == 'race_stop' then
       require('cp.race').stop()
+    elseif cmd.action == 'login' then
+      require('cp.credentials').login(cmd.platform)
+    elseif cmd.action == 'logout' then
+      require('cp.credentials').logout(cmd.platform)
     end
   elseif cmd.type == 'problem_jump' then
     local platform = state.get_platform()
@@ -374,15 +358,6 @@ function M.handle_command(opts)
 
     local setup = require('cp.setup')
     setup.setup_contest(platform, contest_id, problem_id, cmd.language)
-  elseif cmd.type == 'credentials' then
-    local creds = require('cp.credentials')
-    if cmd.subcommand == 'login' then
-      creds.login(cmd.platform)
-    elseif cmd.subcommand == 'logout' then
-      creds.logout(cmd.platform)
-    elseif cmd.subcommand == 'clear' then
-      creds.clear()
-    end
   elseif cmd.type == 'cache' then
     local cache_commands = require('cp.commands.cache')
     cache_commands.handle_cache_command(cmd)

--- a/lua/cp/constants.lua
+++ b/lua/cp/constants.lua
@@ -13,7 +13,8 @@ M.ACTIONS = {
   'race',
   'stress',
   'submit',
-  'credentials',
+  'login',
+  'logout',
 }
 
 M.PLATFORM_DISPLAY_NAMES = {

--- a/lua/cp/credentials.lua
+++ b/lua/cp/credentials.lua
@@ -7,10 +7,7 @@ local state = require('cp.state')
 function M.login(platform)
   platform = platform or state.get_platform()
   if not platform then
-    logger.log(
-      'No platform specified. Usage: :CP credentials login <platform>',
-      vim.log.levels.ERROR
-    )
+    logger.log('No platform specified. Usage: :CP login <platform>', vim.log.levels.ERROR)
     return
   end
 
@@ -35,21 +32,12 @@ end
 function M.logout(platform)
   platform = platform or state.get_platform()
   if not platform then
-    logger.log(
-      'No platform specified. Usage: :CP credentials logout <platform>',
-      vim.log.levels.ERROR
-    )
+    logger.log('No platform specified. Usage: :CP logout <platform>', vim.log.levels.ERROR)
     return
   end
   cache.load()
   cache.clear_credentials(platform)
   logger.log(platform .. ' credentials cleared', vim.log.levels.INFO, true)
-end
-
-function M.clear()
-  cache.load()
-  cache.clear_credentials(nil)
-  logger.log('all credentials cleared', vim.log.levels.INFO, true)
 end
 
 return M

--- a/plugin/cp.lua
+++ b/plugin/cp.lua
@@ -103,8 +103,8 @@ end, {
           end
         end
         return filter_candidates(candidates)
-      elseif args[2] == 'credentials' then
-        return filter_candidates({ 'login', 'logout', 'clear' })
+      elseif args[2] == 'login' or args[2] == 'logout' then
+        return filter_candidates(platforms)
       elseif args[2] == 'race' then
         local candidates = { 'stop' }
         vim.list_extend(candidates, platforms)
@@ -126,8 +126,6 @@ end, {
         cache.load()
         local contests = cache.get_cached_contest_ids(args[3])
         return filter_candidates(contests)
-      elseif args[2] == 'credentials' and vim.tbl_contains({ 'login', 'logout' }, args[3]) then
-        return filter_candidates(platforms)
       elseif args[2] == 'cache' and args[3] == 'clear' then
         local candidates = vim.list_extend({}, platforms)
         table.insert(candidates, '')


### PR DESCRIPTION
## Problem

`:CP credentials login/logout/clear` is verbose and inconsistent with other
actions that are all top-level (`:CP run`, `:CP submit`, etc.). The clear-all
subcommand is also unnecessary since re-logging in overwrites existing
credentials.

## Solution

Replace `:CP credentials {login,logout,clear}` with `:CP login [platform]`
and `:CP logout [platform]`. Remove the clear-all command and the credentials
subcommand dispatch — login/logout are now regular actions routed through the
standard action dispatcher.