### PR TITLE
fix(commands): canonicalize CF contest IDs and auto-restore on action

### DIFF
--- a/lua/cp/commands/init.lua
+++ b/lua/cp/commands/init.lua
@@ -29,9 +29,13 @@ local actions = constants.ACTIONS
 ---@return string
 local function canonicalize_cf_contest(str)
   local id = str:match('/contest/(%d+)') or str:match('/problemset/problem/(%d+)')
-  if id then return id end
+  if id then
+    return id
+  end
   local num = str:match('^(%d+)[A-Za-z]')
-  if num then return num end
+  if num then
+    return num
+  end
   return str
 end
 
@@ -314,7 +318,8 @@ function M.handle_command(opts)
     local restore = require('cp.restore')
     restore.restore_from_current_file()
   elseif cmd.type == 'action' then
-    local CONTEST_ACTIONS = { 'run', 'panel', 'edit', 'interact', 'stress', 'submit', 'next', 'prev', 'pick' }
+    local CONTEST_ACTIONS =
+      { 'run', 'panel', 'edit', 'interact', 'stress', 'submit', 'next', 'prev', 'pick' }
     if vim.tbl_contains(CONTEST_ACTIONS, cmd.action) and not state.get_platform() then
       local restore = require('cp.restore')
       if not restore.restore_from_current_file() then


### PR DESCRIPTION
## Problem

Two gaps in `commands/init.lua`. Codeforces contest IDs were passed through raw, so full URLs (e.g. `https://codeforces.com/contest/1933/problem/A`) or problem IDs with trailing letters (e.g. `1933A`) caused scraper URL construction to fail. Separately, action commands like `:CP run` silently failed when invoked with no active contest instead of attempting to recover from the current file's cached state.

## Solution

Add `canonicalize_cf_contest` to normalize URLs and strip trailing problem letters in `parse_command`. Add a guard in `handle_command` that calls `restore_from_current_file()` before dispatching any contest-requiring action when no platform is active, returning early only if no cached state is found.

Closes #306. Closes #308.