### PR TITLE
refactor: remove open_url config option in favour of :CP open

### DIFF
--- a/doc/cp.nvim.txt
+++ b/doc/cp.nvim.txt
@@ -113,7 +113,6 @@ Configuration is done via `vim.g.cp`. Set this before using the plugin:
           default_language  = 'cpp',
         },
       },
-      open_url = true,
       debug = false,
       ui = {
         ansi = true,
@@ -186,8 +185,6 @@ run CSES problems with Rust using the single schema:
                         Should return full filename with extension.
                         (default: concatenates contest_id and problem_id, lowercased)
         {ui}            (|CpUI|) UI settings: panel, diff backend, picker.
-        {open_url}      (boolean) Open the contest & problem url in the browser
-                        when a new contest is opened or the active problem changes.
 
                                                                   *CpPlatform*
     Fields: ~

--- a/lua/cp/config.lua
+++ b/lua/cp/config.lua
@@ -101,7 +101,6 @@
 ---@field templates? CpTemplatesConfig
 ---@field hooks Hooks
 ---@field debug boolean
----@field open_url boolean
 ---@field scrapers string[]
 ---@field filename? fun(contest: string, contest_id: string, problem_id?: string, config: cp.Config, language?: string): string
 ---@field ui CpUI
@@ -118,7 +117,6 @@ local utils = require('cp.utils')
 -- defaults per the new single schema
 ---@type cp.Config
 M.defaults = {
-  open_url = false,
   languages = {
     cpp = {
       extension = 'cc',
@@ -362,7 +360,6 @@ function M.setup(user_config)
     hooks = { cfg.hooks, { 'table' } },
     ui = { cfg.ui, { 'table' } },
     debug = { cfg.debug, { 'boolean', 'nil' }, true },
-    open_url = { cfg.open_url, { 'boolean', 'nil' }, true },
     filename = { cfg.filename, { 'function', 'nil' }, true },
     scrapers = {
       cfg.scrapers,

--- a/lua/cp/setup.lua
+++ b/lua/cp/setup.lua
@@ -164,7 +164,6 @@ end
 ---@param language? string
 function M.setup_contest(platform, contest_id, problem_id, language)
   local old_platform, old_contest_id = state.get_platform(), state.get_contest_id()
-  local old_problem_id = state.get_problem_id()
 
   state.set_platform(platform)
   state.set_contest_id(contest_id)
@@ -205,13 +204,6 @@ function M.setup_contest(platform, contest_id, problem_id, language)
     local pid = problem_id and problem_id or problems[1].id
     M.setup_problem(pid, language)
     start_tests(platform, contest_id, problems)
-
-    local is_new_problem = old_problem_id ~= pid
-    local should_open_url = config_module.get_config().open_url
-      and (is_new_contest or is_new_problem)
-    if should_open_url and contest_data.url then
-      vim.ui.open(contest_data.url:format(pid))
-    end
   end
 
   local contest_data = cache.get_contest_data(platform, contest_id)


### PR DESCRIPTION
## Problem

`open_url` automatically opened the browser on contest load and problem
change, which is now redundant with `:CP open`.

## Solution

Remove the `open_url` field from `cp.Config`, its default, its
validation, and the call site in `setup_contest`. Remove documentation
from `cp.nvim.txt`.