### PR TITLE
feat(config): add submit_id platform override for language selection

### DIFF
--- a/lua/cp/config.lua
+++ b/lua/cp/config.lua
@@ -8,6 +8,7 @@
 ---@field extension string
 ---@field commands CpLangCommands
 ---@field template? string
+---@field submit_id? string
 
 ---@class CpTemplatesConfig
 ---@field cursor_marker? string
@@ -16,6 +17,7 @@
 ---@field extension? string
 ---@field commands? CpLangCommands
 ---@field template? string
+---@field submit_id? string
 
 ---@class CpPlatform
 ---@field enabled_languages string[]
@@ -292,6 +294,9 @@ local function merge_lang(base, ov)
   end
   if ov.template then
     out.template = ov.template
+  end
+  if ov.submit_id then
+    out.submit_id = ov.submit_id
   end
   return out
 end

--- a/lua/cp/submit.lua
+++ b/lua/cp/submit.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local cache = require('cp.cache')
+local config = require('cp.config')
 local logger = require('cp.log')
 local state = require('cp.state')
 
@@ -56,6 +57,12 @@ function M.submit(opts)
   end
   source_file = vim.fn.fnamemodify(source_file, ':p')
 
+  local lang_result = config.get_language_for_platform(platform, language)
+  local submit_language = language
+  if lang_result.valid and lang_result.effective and lang_result.effective.submit_id then
+    submit_language = lang_result.effective.submit_id
+  end
+
   prompt_credentials(platform, function(creds)
     vim.cmd.update()
     vim.notify('[cp.nvim] Submitting...', vim.log.levels.INFO)
@@ -64,7 +71,7 @@ function M.submit(opts)
       platform,
       contest_id,
       problem_id,
-      language,
+      submit_language,
       source_file,
       creds,
       function(ev)

--- a/tests/test_scrapers.py
+++ b/tests/test_scrapers.py
@@ -1,5 +1,6 @@
 import pytest
 
+from scrapers.language_ids import LANGUAGE_IDS, get_language_id
 from scrapers.models import (
     ContestListResult,
     MetadataResult,
@@ -137,3 +138,21 @@ def test_scraper_metadata_error(run_scraper_offline, scraper, contest_id):
     assert objs
     assert objs[-1].get("success") is False
     assert objs[-1].get("error")
+
+
+EXPECTED_PLATFORMS = {"atcoder", "codeforces", "cses", "usaco", "kattis", "codechef"}
+EXPECTED_LANGUAGES = {"cpp", "python"}
+
+
+def test_language_ids_coverage():
+    assert set(LANGUAGE_IDS.keys()) == EXPECTED_PLATFORMS
+    for platform in EXPECTED_PLATFORMS:
+        for lang in EXPECTED_LANGUAGES:
+            lid = get_language_id(platform, lang)
+            assert lid is not None, f"Missing language ID: {platform}/{lang}"
+            assert isinstance(lid, str) and lid, f"Empty language ID: {platform}/{lang}"
+
+
+def test_language_ids_unknown_returns_none():
+    assert get_language_id("codeforces", "rust") is None
+    assert get_language_id("nonexistent", "cpp") is None


### PR DESCRIPTION
## Problem

The submission language ID is hardcoded per platform in `language_ids.py`
(e.g. CF `"89"` = GNU G++17 7.3.0). Users have no way to choose a
different compiler version like G++20 or C++23 when submitting.

## Solution

Add `submit_id?: string` to `CpPlatformOverrides` and `CpLanguage`. When
set, `submit.lua` passes the resolved ID directly to the scraper, bypassing
the default `language_ids.py` lookup. Usage:

```lua
platforms = {
  codeforces = {
    overrides = { cpp = { submit_id = "91" } },  -- GNU G++20
  },
}
```

Also adds tests verifying `language_ids.py` has entries for all six
platforms and both core languages, and that unknown lookups return `nil`.

Closes #311.