### PR TITLE
fix: correct Codeforces language version IDs and default to C++20

### DIFF
--- a/doc/cp.nvim.txt
+++ b/doc/cp.nvim.txt
@@ -1039,18 +1039,18 @@ Submit the current solution to the online judge.
 SUBMIT LANGUAGE VERSIONS                              *cp-submit-language*
 
 When submitting, cp.nvim selects a language version for the platform.
-The default is C++17 for cpp and Python 3 for python.
+The default is C++20 for cpp and Python 3 for python.
 
 Configuring a version ~
 
 Set {version} globally or per-platform:
 >lua
     languages = {
-      cpp = { version = "c++20", ... },
+      cpp = { version = "c++23", ... },
     },
     platforms = {
-      atcoder = {
-        overrides = { cpp = { version = "c++23" } },
+      codeforces = {
+        overrides = { cpp = { version = "c++17" } },
       },
     },
 <
@@ -1058,7 +1058,7 @@ Available versions per platform ~
 
   Platform    cpp              python
   AtCoder     c++23            python3
-  Codeforces  c++17            python3
+  Codeforces  c++17/20/23      python3, pypy3
   CSES        c++17            python3
   Kattis      c++17/20/23      python3
   USACO       c++17/20/23      python3

--- a/lua/cp/constants.lua
+++ b/lua/cp/constants.lua
@@ -75,7 +75,10 @@ M.signal_codes = {
 
 M.LANGUAGE_VERSIONS = {
   atcoder = { cpp = { ['c++23'] = '6017' }, python = { python3 = '6082' } },
-  codeforces = { cpp = { ['c++17'] = '89' }, python = { python3 = '70' } },
+  codeforces = {
+    cpp = { ['c++17'] = '54', ['c++20'] = '89', ['c++23'] = '91' },
+    python = { python3 = '31', pypy3 = '70' },
+  },
   cses = { cpp = { ['c++17'] = 'C++17' }, python = { python3 = 'Python3' } },
   kattis = {
     cpp = { ['c++17'] = 'C++', ['c++20'] = 'C++', ['c++23'] = 'C++' },
@@ -88,6 +91,6 @@ M.LANGUAGE_VERSIONS = {
   codechef = { cpp = { ['c++17'] = 'C++ 17' }, python = { python3 = 'Python 3' } },
 }
 
-M.DEFAULT_VERSIONS = { cpp = 'c++17', python = 'python3' }
+M.DEFAULT_VERSIONS = { cpp = 'c++20', python = 'python3' }
 
 return M

--- a/lua/cp/race.lua
+++ b/lua/cp/race.lua
@@ -61,9 +61,10 @@ local function refetch_start_time()
   local new_time = cache.get_contest_start_time(race_state.platform, race_state.contest_id)
   if new_time and new_time ~= race_state.start_time then
     race_state.start_time = new_time
-    race_state.contest_name =
-      cache.get_contest_display_name(race_state.platform, race_state.contest_id)
-      or race_state.contest_id
+    race_state.contest_name = cache.get_contest_display_name(
+      race_state.platform,
+      race_state.contest_id
+    ) or race_state.contest_id
   end
 end
 
@@ -121,11 +122,7 @@ local function race_try_setup(platform, contest_id, language, attempt, token)
       end
       if attempt >= MAX_RETRY_ATTEMPTS then
         logger.log(
-          ('Failed to load %s contest "%s" after %d attempts'):format(
-            display,
-            contest_id,
-            attempt
-          ),
+          ('Failed to load %s contest "%s" after %d attempts'):format(display, contest_id, attempt),
           { level = vim.log.levels.ERROR }
         )
         return


### PR DESCRIPTION
## Problem

`LANGUAGE_VERSIONS` mapped CF `c++17` to `89` (actually GNU G++20) and
defaulted to `c++17`, which didn't match any CF entry. Helpdocs listed
CF as having only `c++17`.

## Solution

Fix CF version map to `c++17 → 54`, `c++20 → 89`, `c++23 → 91`, add
`pypy3 → 70`. Change `DEFAULT_VERSIONS.cpp` to `c++20` (no behavioral
change — `89` was already the submit default). Update helpdocs. Fix
StyLua formatting in `race.lua`.